### PR TITLE
Issue 4724: vagrant box defines more cpus than available on host

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -57,7 +57,7 @@ def configure(config)
       # sysctl returns Bytes, converting to MB...
       mem = `sysctl -n hw.memsize`.to_i / 1024 / 1024 / 4
     elsif host =~ /linux/
-      cpus = `nproc`.to_i
+      cpus = `nproc`.to_i / 2
       # meminfo returns KB, converting to MB...
       mem = `grep 'MemTotal' /proc/meminfo | sed -e 's/MemTotal://' -e 's/ kB//'`.to_i / 1024 / 4
     else


### PR DESCRIPTION
https://github.com/hashbangcode/vlad/issues/350

nproc includes both real cores and hyperthreaded or psuedo-cores but VirtualBox can only use real cores as CPUs for Vitualization purposes. Most people are now using nproc divided by 2, as a reasonable default value when auto detecting CPUs in a Vagrantfile